### PR TITLE
feat: variant without header

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -186,8 +186,9 @@ h3 {
 }
 
 
+.docsNavContainer,
 .navPusher {
-  padding-top: 60px;
+  padding-top: 0 !important;
 }
 
 /* Edit page button */
@@ -314,4 +315,8 @@ img {
   text-align: center;
   opacity: 0;
   text-transform: uppercase;
+}
+
+.fixedHeaderContainer {
+  display: none;
 }


### PR DESCRIPTION
When the new Platform powered variant of the site is launched we will
serve the academy within an iframe. Once that change has
been made we will now longer need the header block on this
site.

![Screenshot 2022-06-05 at 22 35 59](https://user-images.githubusercontent.com/472589/172069519-8a2c8068-2368-4edf-a91e-c7f75fb8eb59.jpg)



